### PR TITLE
PNAPP-20 - Prevent empty paragraphs and titles from overlapping

### DIFF
--- a/application-paragraph-numbering-macro/src/main/resources/paragraphsnumbering.css
+++ b/application-paragraph-numbering-macro/src/main/resources/paragraphsnumbering.css
@@ -33,6 +33,17 @@
   display: inline-block;
 }
 
+.paragraphs-numbering-root p > span:empty:after,
+.paragraphs-numbering-root h1 > span:empty:after,
+.paragraphs-numbering-root h2 > span:empty:after,
+.paragraphs-numbering-root h3 > span:empty:after,
+.paragraphs-numbering-root h4 > span:empty:after,
+.paragraphs-numbering-root h5 > span:empty:after,
+.paragraphs-numbering-root h6 > span:empty:after {
+  display: inline-block;
+  content: "";
+}
+
 .paragraphs-numbering-root h1::before,
 .paragraphs-numbering-root h2::before,
 .paragraphs-numbering-root h3::before,


### PR DESCRIPTION
Fixes empty paragraphs and titles from overlapping. See https://jira.xwiki.org/browse/PNAPP-20

Before:
![numbers overlapping](https://jira.xwiki.org/secure/attachment/40652/40652_image-2022-08-12-10-44-29-352.png)

After:
![numbers not overlapping anymore](https://jira.xwiki.org/secure/thumbnail/40653/_thumb_40653.png)